### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/chrisvaughn/gamedex/security/code-scanning/3](https://github.com/chrisvaughn/gamedex/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations:
- The `test` job requires read access to repository contents to check out the code and install dependencies.
- The `docker-build` job also requires read access to repository contents for building the Docker image.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or individually for each job. In this case, adding it at the root level is more concise and ensures consistency across jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
