### PR TITLE
Potential fix for code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 import uvicorn
 from fastapi import Depends, FastAPI, Form, HTTPException, Path, Query, Request
+from urllib.parse import urlparse
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -435,9 +436,12 @@ async def update_game(
                 pass  # Skip invalid ratings
 
     db.commit()
-    return RedirectResponse(
-        url=f"/games/{game_id}?msg=Game+updated+successfully", status_code=303
-    )
+    from urllib.parse import urlparse
+    redirect_url = f"/games/{game_id}?msg=Game+updated+successfully"
+    parsed_url = urlparse(redirect_url)
+    if not parsed_url.netloc and not parsed_url.scheme:
+        return RedirectResponse(url=redirect_url, status_code=303)
+    return RedirectResponse(url="/?msg=Invalid+redirect", status_code=303)
 
 
 @app.delete("/games/{game_id}")


### PR DESCRIPTION
Potential fix for [https://github.com/chrisvaughn/gamedex/security/code-scanning/1](https://github.com/chrisvaughn/gamedex/security/code-scanning/1)

To fix the issue, we need to ensure that the `game_id` parameter is validated before being used in the URL construction. Since the `game_id` is already constrained to be a positive integer, the risk is minimal, but we can further mitigate it by explicitly validating that the constructed URL is a relative path within the application. This can be achieved using the `urlparse` function from Python's standard library to ensure the `netloc` and `scheme` attributes are empty, confirming that the URL is safe for redirection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
